### PR TITLE
exclude unicode subtypes from type checking

### DIFF
--- a/src/spikeinterface/core/unitsaggregationsorting.py
+++ b/src/spikeinterface/core/unitsaggregationsorting.py
@@ -88,7 +88,7 @@ class UnitsAggregationSorting(BaseSorting):
                     existing_dtype = property_keys[prop_name]
                     new_dtype = sort.get_property(prop_name).dtype
                     if existing_dtype != new_dtype:
-                        if not (existing_dtype.kind == 'U' and new_dtype.kind == 'U'):
+                        if not (existing_dtype.kind == "U" and new_dtype.kind == "U"):
                             print(f"Skipping property '{prop_name}': difference in dtype between sortings")
                             del property_keys[prop_name]
                             deleted_keys.append(prop_name)

--- a/src/spikeinterface/core/unitsaggregationsorting.py
+++ b/src/spikeinterface/core/unitsaggregationsorting.py
@@ -88,9 +88,7 @@ class UnitsAggregationSorting(BaseSorting):
                     existing_dtype = property_keys[prop_name]
                     new_dtype = sort.get_property(prop_name).dtype
                     if existing_dtype != new_dtype:
-                        existing_is_unicode = existing_dtype.kind == 'U'
-                        new_is_unicode = new_dtype.kind == 'U'
-                        if not (existing_is_unicode and new_is_unicode):
+                        if not (existing_dtype.kind == 'U' and new_dtype.kind == 'U'):
                             print(f"Skipping property '{prop_name}': difference in dtype between sortings")
                             del property_keys[prop_name]
                             deleted_keys.append(prop_name)

--- a/src/spikeinterface/core/unitsaggregationsorting.py
+++ b/src/spikeinterface/core/unitsaggregationsorting.py
@@ -85,10 +85,15 @@ class UnitsAggregationSorting(BaseSorting):
                 if prop_name in deleted_keys:
                     continue
                 if prop_name in property_keys:
-                    if property_keys[prop_name] != sort.get_property(prop_name).dtype:
-                        print(f"Skipping property '{prop_name}: difference in dtype between sortings'")
-                        del property_keys[prop_name]
-                        deleted_keys.append(prop_name)
+                    existing_dtype = property_keys[prop_name]
+                    new_dtype = sort.get_property(prop_name).dtype
+                    if existing_dtype != new_dtype:
+                        existing_is_unicode = existing_dtype.kind == 'U'
+                        new_is_unicode = new_dtype.kind == 'U'
+                        if not (existing_is_unicode and new_is_unicode):
+                            print(f"Skipping property '{prop_name}': difference in dtype between sortings")
+                            del property_keys[prop_name]
+                            deleted_keys.append(prop_name)
                 else:
                     property_keys[prop_name] = sort.get_property(prop_name).dtype
         for prop_name in property_keys:


### PR DESCRIPTION
Hi,

I was aggreagating 2 sortings, one had quality types "mua", "sua" dtype('<U3'), the other one included a "good" so dtype('<U4'). For this reason "quality" was skipped ( ` print(f"Skipping property '{prop_name}: difference in dtype between sortings'")`). With this modification the code will avoid distinguishing by number of charachters.